### PR TITLE
Comment out the openssl recursive build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,11 +89,23 @@ if(BUILD_DEPENDENCIES)
   endif()
 
   if (USE_OPENSSL)
-    set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
-                   -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM}
-                   -DOPENSSL_EXTRA=${OPENSSL_EXTRA})
-    build_dependency(openssl ${BUILD_ARGS})
-    set(OPENSSL_ROOT_DIR ${OPEN_SRC_INSTALL_PREFIX})
+  # Canvas specific customization of the offical upstream CMakeLists.
+  #
+  # Change Summary: Comment out the call to build OpenSSL
+  #
+  # This change allows build_dependencies to be on; however, OpenSSL
+  # is not built from source because other dependencies are likely to
+  # rely on the distro (system installed) OpenSSL. This is preferable 
+  # because it pushes the management of OpenSSL to the package manager
+  # which ensures OpenSSL aligns for all of the software on the host.
+  # It also ensures only one copy of OpenSSL which must be up to date
+  # to keep the host secure.
+  #  
+  #  set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
+  #                 -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM}
+  #                 -DOPENSSL_EXTRA=${OPENSSL_EXTRA})
+  #  build_dependency(openssl ${BUILD_ARGS})
+  #  set(OPENSSL_ROOT_DIR ${OPEN_SRC_INSTALL_PREFIX})
   elseif(USE_MBEDTLS)
     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS})
     build_dependency(mbedtls ${BUILD_ARGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,12 +100,13 @@ if(BUILD_DEPENDENCIES)
   # which ensures OpenSSL aligns for all of the software on the host.
   # It also ensures only one copy of OpenSSL which must be up to date
   # to keep the host secure.
-  #  
+  # ----------------------------BEGIN CANVAS CUSTOMIZATION
   #  set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
   #                 -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM}
   #                 -DOPENSSL_EXTRA=${OPENSSL_EXTRA})
   #  build_dependency(openssl ${BUILD_ARGS})
   #  set(OPENSSL_ROOT_DIR ${OPEN_SRC_INSTALL_PREFIX})
+  # ----------------------------END CANVAS CUSTOMIZATION
   elseif(USE_MBEDTLS)
     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS})
     build_dependency(mbedtls ${BUILD_ARGS})


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This change comments out the call to recursively build OpenSSL in favor of using the OS implementation. This change is Canvas specific because they recursively build the other dependencies for WebRTC.

