### PR TITLE
Cherry-pick #1048 from upstream to fix Clang build

### DIFF
--- a/CMake/Dependencies/libsrtp-CMakeLists.txt
+++ b/CMake/Dependencies/libsrtp-CMakeLists.txt
@@ -4,6 +4,7 @@ project(libsrtp-download NONE)
 
 
 SET(CONFIGURE_COMMAND "")
+SET(PATCH_COMMAND "")
 
 # There is known bug in libsrtp where cross compiling using configure on ARM fails. Do not
 # enable this option if cross compilng on ARM
@@ -36,6 +37,9 @@ else()
   set(LIBSRTP_SHARED_LIBS ON)
 endif()
 
+if (NOT WIN32)
+    set(PATCH_COMMAND ${PATCH_COMMAND} git apply --ignore-whitespace ${CMAKE_SOURCE_DIR}/../../CMake/Dependencies/libsrtp-gcc-10_bit_string.patch)
+endif()
 
 if (USE_OPENSSL)
   set(LIBSRTP_ENABLE_OPENSSL ON)
@@ -48,6 +52,7 @@ include(ExternalProject)
 ExternalProject_Add(project_libsrtp
     GIT_REPOSITORY    https://github.com/cisco/libsrtp.git
     GIT_TAG           v2.3.0
+    PATCH_COMMAND     ${PATCH_COMMAND}
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
                       -D CMAKE_INSTALL_PREFIX:STRING=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libsrtp-gcc-10_bit_string.patch
+++ b/CMake/Dependencies/libsrtp-gcc-10_bit_string.patch
@@ -1,0 +1,26 @@
+diff --git a/crypto/math/datatypes.c b/crypto/math/datatypes.c
+index 001584c..4fcb396 100644
+--- a/crypto/math/datatypes.c
++++ b/crypto/math/datatypes.c
+@@ -79,7 +79,7 @@ int octet_get_weight(uint8_t octet)
+
+ /* the value MAX_PRINT_STRING_LEN is defined in datatypes.h */
+
+-char bit_string[MAX_PRINT_STRING_LEN];
++static char bit_string[MAX_PRINT_STRING_LEN];
+
+ uint8_t srtp_nibble_to_hex_char(uint8_t nibble)
+ {
+diff --git a/test/util.c b/test/util.c
+index 2abc28e..c0f7614 100644
+--- a/test/util.c
++++ b/test/util.c
+@@ -49,7 +49,7 @@
+ #include <stdint.h>
+
+ /* include space for null terminator */
+-char bit_string[MAX_PRINT_STRING_LEN + 1];
++static char bit_string[MAX_PRINT_STRING_LEN + 1];
+
+ static inline int hex_char_to_nibble(uint8_t c)
+ {

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1021,13 +1021,16 @@ STATUS signalingMessageReceived(UINT64 customData, PReceivedSignalingMessage pRe
 
     switch (pReceivedSignalingMessage->signalingMessage.messageType) {
         case SIGNALING_MESSAGE_TYPE_OFFER:
+            // Check if we already have an ongoing master session with the same peer
+            CHK_ERR(!peerConnectionFound, STATUS_INVALID_OPERATION, "Peer connection %s is in progress", pReceivedSignalingMessage->signalingMessage.peerClientId);
+
             /*
              * Create new streaming session for each offer, then insert the client id and streaming session into
              * pRtcPeerConnectionForRemoteClient for subsequent ice candidate messages. Lastly check if there is
              * any ice candidate messages queued in pPendingSignalingMessageForRemoteClient. If so then submit
              * all of them.
              */
-            if (pSampleConfiguration->streamingSessionCount == SIZEOF(pSampleConfiguration->sampleStreamingSessionList)) {
+            if (pSampleConfiguration->streamingSessionCount == ARRAY_SIZE(pSampleConfiguration->sampleStreamingSessionList)) {
                 DLOGW("Max simultaneous streaming session count reached.");
                 CHK(FALSE, retStatus);
             }


### PR DESCRIPTION
The PR https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/1048 fixes builds on Clang by patching libsrtp to make a variable that was defined twice in the global scope `static`. 

Original commit message:

Fixing the sample application to fail on duplicate client id (master) (#1048)

* Fixing the sample application to fail on duplicate client id (master). Also, fixing a bug with the session count max. Both issues are reported by the customer.

* Fixing static build by applying a patch to libsrtp

* Disable patching on Windows as git apply command fails on Travis

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
